### PR TITLE
Renamed `generateTsRestContractFromOpenAPI` function to `generateContract`

### DIFF
--- a/apps/playground/src/hooks/useOpenAPITsRest.ts
+++ b/apps/playground/src/hooks/useOpenAPITsRest.ts
@@ -1,4 +1,4 @@
-import { generateTsRestContractFromOpenAPI } from "@openapi-ts-rest/core";
+import { generateContract } from "@openapi-ts-rest/core";
 import jsYaml from "js-yaml";
 import useSWRImmutable from "swr/immutable";
 
@@ -11,7 +11,7 @@ export function useOpenAPITsRest(openAPIDoc: string) {
   return useSWRImmutable(
     debouncedOpenAPIDoc,
     async (value) =>
-      await generateTsRestContractFromOpenAPI({
+      await generateContract({
         input: jsYaml.load(value) as string,
       }),
     { compare: (a, b) => a === b }

--- a/apps/playground/src/hooks/useOpenAPITsRest.ts
+++ b/apps/playground/src/hooks/useOpenAPITsRest.ts
@@ -12,7 +12,7 @@ export function useOpenAPITsRest(openAPIDoc: string) {
     debouncedOpenAPIDoc,
     async (value) =>
       await generateContract({
-        input: jsYaml.load(value) as string,
+        openApi: jsYaml.load(value) as string,
       }),
     { compare: (a, b) => a === b }
   );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,13 +12,13 @@ const program = new Command();
 program
   .version(packageJson.version)
   .description("Generates a ts-rest contract from an OpenAPI schema.")
-  .argument("<input>", "The input OpenAPI schema file.")
+  .argument("<openApi>", "The OpenAPI schema file.")
   .requiredOption("-o, --output <output>", "The output file.")
-  .action(async (input, { output }) => {
+  .action(async (openApi, { output }) => {
     const prettierConfig = await prettier.resolveConfig("./");
 
     const result = await generateContract({
-      input,
+      openApi,
       prettierConfig,
     });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Command } from "@commander-js/extra-typings";
-import { generateTsRestContractFromOpenAPI } from "@openapi-ts-rest/core";
+import { generateContract } from "@openapi-ts-rest/core";
 import { writeFileSync } from "fs";
 import prettier from "prettier";
 
@@ -17,7 +17,7 @@ program
   .action(async (input, { output }) => {
     const prettierConfig = await prettier.resolveConfig("./");
 
-    const result = await generateTsRestContractFromOpenAPI({
+    const result = await generateContract({
       input,
       prettierConfig,
     });

--- a/packages/core/src/generateContract.ts
+++ b/packages/core/src/generateContract.ts
@@ -19,7 +19,7 @@ import {
 } from "./lib/ts.js";
 import { AstTsWriter } from "./lib/utils.js";
 
-interface GenerateTsRestContractFromOpenAPIOptions {
+export interface GenerateContractOptions {
   /**
    * The OpenAPI schema to generate the ts-rest contract from.
    * It can be either an OpenAPI schema object or a URL to an OpenAPI schema.
@@ -33,12 +33,12 @@ interface GenerateTsRestContractFromOpenAPIOptions {
 
 /**
  * Generates a ts-rest contract from an OpenAPI schema.
- * @param {GenerateTsRestContractFromOpenAPIOptions} options - The options for the generation.
+ * @param {generateContractOptions} options - The options for the generation.
  */
-export async function generateTsRestContractFromOpenAPI({
+export async function generateContract({
   input,
   prettierConfig,
-}: GenerateTsRestContractFromOpenAPIOptions): Promise<string> {
+}: GenerateContractOptions): Promise<string> {
   const openApiSchema = (await SwaggerParser.bundle(input as never)) as OpenAPIObject;
 
   const ctx = createContext(openApiSchema);

--- a/packages/core/src/generateContract.ts
+++ b/packages/core/src/generateContract.ts
@@ -24,7 +24,7 @@ export interface GenerateContractOptions {
    * The OpenAPI schema to generate the ts-rest contract from.
    * It can be either an OpenAPI schema object or a URL to an OpenAPI schema.
    */
-  input: OpenAPIObject | string;
+  openApi: OpenAPIObject | string;
   /**
    * The Prettier configuration to use for formatting the generated code.
    */
@@ -36,10 +36,10 @@ export interface GenerateContractOptions {
  * @param {generateContractOptions} options - The options for the generation.
  */
 export async function generateContract({
-  input,
+  openApi,
   prettierConfig,
 }: GenerateContractOptions): Promise<string> {
-  const openApiSchema = (await SwaggerParser.bundle(input as never)) as OpenAPIObject;
+  const openApiSchema = (await SwaggerParser.bundle(openApi as never)) as OpenAPIObject;
 
   const ctx = createContext(openApiSchema);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./generateTsRestContractFromOpenAPI";
+export * from "./generateContract";

--- a/packages/core/tests/__snapshots__/generateTsRestContractFromOpenAPI.test.ts.snap
+++ b/packages/core/tests/__snapshots__/generateTsRestContractFromOpenAPI.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`generateTsRestContractFromOpenAPI > should match snapshot for https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml 1`] = `
+exports[`generateContract > should match snapshot for https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml 1`] = `
 "import { initContract } from "@ts-rest/core";
 import { z } from "zod";
 
@@ -77,7 +77,7 @@ export const contract = c.router({
 "
 `;
 
-exports[`generateTsRestContractFromOpenAPI > should match snapshot for https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/openapi-v3/defibrillatori-example.yaml 1`] = `
+exports[`generateContract > should match snapshot for https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/openapi-v3/defibrillatori-example.yaml 1`] = `
 "import { initContract } from "@ts-rest/core";
 import { z } from "zod";
 

--- a/packages/core/tests/generateTsRestContractFromOpenAPI.test.ts
+++ b/packages/core/tests/generateTsRestContractFromOpenAPI.test.ts
@@ -9,27 +9,30 @@ const OPENAPI_DOCS = [
 ];
 
 describe("generateContract", () => {
-  it.each(OPENAPI_DOCS)("should successfully transpile module without ts errors", async (input) => {
+  it.each(OPENAPI_DOCS)(
+    "should successfully transpile module without ts errors",
+    async (openApi) => {
+      const module = await generateContract({
+        openApi,
+      });
+
+      const output = ts.transpileModule(module, {
+        compilerOptions: {
+          module: ts.ModuleKind.NodeNext,
+          noEmit: true,
+          strict: true,
+          target: ts.ScriptTarget.ESNext,
+        },
+        reportDiagnostics: true,
+      });
+
+      expect(output.diagnostics).toHaveLength(0);
+    }
+  );
+
+  it.each(OPENAPI_DOCS)("should match snapshot for %s", async (openApi) => {
     const module = await generateContract({
-      input,
-    });
-
-    const output = ts.transpileModule(module, {
-      compilerOptions: {
-        module: ts.ModuleKind.NodeNext,
-        noEmit: true,
-        strict: true,
-        target: ts.ScriptTarget.ESNext,
-      },
-      reportDiagnostics: true,
-    });
-
-    expect(output.diagnostics).toHaveLength(0);
-  });
-
-  it.each(OPENAPI_DOCS)("should match snapshot for %s", async (input) => {
-    const module = await generateContract({
-      input,
+      openApi,
     });
 
     expect(module).toMatchSnapshot();

--- a/packages/core/tests/generateTsRestContractFromOpenAPI.test.ts
+++ b/packages/core/tests/generateTsRestContractFromOpenAPI.test.ts
@@ -1,15 +1,16 @@
 import ts from "typescript";
+import { describe, expect, it } from "vitest";
 
-import { generateTsRestContractFromOpenAPI } from "../src/generateTsRestContractFromOpenAPI";
+import { generateContract } from "../src/generateContract";
 
 const OPENAPI_DOCS = [
   "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml",
   "https://raw.githubusercontent.com/teamdigitale/api-openapi-samples/master/openapi-v3/defibrillatori-example.yaml",
 ];
 
-describe("generateTsRestContractFromOpenAPI", () => {
+describe("generateContract", () => {
   it.each(OPENAPI_DOCS)("should successfully transpile module without ts errors", async (input) => {
-    const module = await generateTsRestContractFromOpenAPI({
+    const module = await generateContract({
       input,
     });
 
@@ -27,7 +28,7 @@ describe("generateTsRestContractFromOpenAPI", () => {
   });
 
   it.each(OPENAPI_DOCS)("should match snapshot for %s", async (input) => {
-    const module = await generateTsRestContractFromOpenAPI({
+    const module = await generateContract({
       input,
     });
 


### PR DESCRIPTION
Also renamed the `input` option property to `openApi`